### PR TITLE
LIBITD-282. Minor fix to keep server running if no xsl found.

### DIFF
--- a/src/main/java/edu/umd/lib/wufoosysaid/EntryController.java
+++ b/src/main/java/edu/umd/lib/wufoosysaid/EntryController.java
@@ -242,10 +242,6 @@ public class EntryController extends HttpServlet {
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
           "Error occured while attempting to create requests from entry.");
       return;
-      // BAD TEMPORARY FIX, Exit if no XSL was found!
-      // (To avoid multiple do post requests by container)
-
-      // System.exit(0);
     }
   }
 }


### PR DESCRIPTION
return instead of System.exit(0);

https://issues.umd.edu/browse/LIBITD-282
